### PR TITLE
Keep existing pool transactions

### DIFF
--- a/sovrin_common/setup_util.py
+++ b/sovrin_common/setup_util.py
@@ -26,7 +26,13 @@ class Setup:
         self.setupCommon()
         self.setupSampleInvites()
 
-    def setupTxns(self, key):
+    def setupTxns(self, key, force: bool = False):
+        """
+        Create base transactions
+
+        :param key: ledger
+        :param force: replace existing transaction files
+        """
         import data
         dataDir = os.path.dirname(data.__file__)
 
@@ -40,13 +46,18 @@ class Setup:
             "live": Environment("pool_transactions_live",
                                 "transactions_live")
         }
-        for envName, env in allEnvs.items():
-            for keyName, fileName in env._asdict().items():
-                if keyName == key:
-                    sourceFilePath = os.path.join(dataDir, fileName)
-                    if os.path.exists(sourceFilePath):
-                        destFilePath = os.path.join(self.base_dir, fileName)
-                        copyfile(sourceFilePath, destFilePath)
+        for env in allEnvs.values():
+            fileName = getattr(env, key, None)
+            if not fileName:
+                continue
+            sourceFilePath = os.path.join(dataDir, fileName)
+            if not os.path.exists(sourceFilePath):
+                continue
+            destFilePath = os.path.join(self.base_dir, fileName)
+            if os.path.exists(destFilePath) and not force:
+                continue
+            destFilePath = os.path.join(self.base_dir, fileName)
+            copyfile(sourceFilePath, destFilePath)
 
         return self
 

--- a/sovrin_common/setup_util.py
+++ b/sovrin_common/setup_util.py
@@ -56,7 +56,6 @@ class Setup:
             destFilePath = os.path.join(self.base_dir, fileName)
             if os.path.exists(destFilePath) and not force:
                 continue
-            destFilePath = os.path.join(self.base_dir, fileName)
             copyfile(sourceFilePath, destFilePath)
 
         return self


### PR DESCRIPTION
Add argument 'force' to setupTxns() to prevent overriding existing transaction files on setup